### PR TITLE
CI/CD/Security/Minor change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: release
+
+on: push
+
+jobs:
+  ubuntu-release:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_HOME: /home/runner/.cargo
+      PREFIX: /home/runner/install
+    steps:
+      - name: Linux Cargo Cache
+        id: linux-cache-cargo
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cargo
+          key: linux-cache-cargo
+      - name: Install botan
+        run: sudo apt install -y libbotan-2-dev
+      - uses: actions/checkout@v4
+      - run: sudo apt install cargo
+      - run: make
+      - run: make install
+      - name: archive artifacts on sha
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-${{ github.sha }}
+          path: /home/runner/install
+      - name: archive artifacts on tag
+        if: github.ref_type == 'tag'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-${{ github.ref }}
+          path: install
+
+  windows-release:
+    runs-on: windows-latest
+    env:
+      CARGO_HOME: "C:\\Users\\runneradmin\\.cargo"
+    steps:
+      - name: Get sources
+        uses: actions/checkout@v4
+      - name: Windows Cargo Cache
+        id: windows-cache-cargo
+        uses: actions/cache@v4
+        with:
+          path: "C:\\Users\\runneradmin\\.cargo"
+          key: windows-cache-cargo
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+      - name: Get botan
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-d39f573718993ceab57564e46dfacd4ad3017794
+          github-token: ${{ secrets.ALL_REPO_ACCESS_TOKEN }}
+          repository: plancksecurity/botan
+          run-id: 7625124553
+          path: .
+      - name: Relocate lib
+        run: cp lib\botan.lib botan.lib
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+        env:
+          RUSTFLAGS: -luser32
+      - name: archive artifacts on sha
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-${{ github.sha }}
+          path: target\release
+      - name: archive artifacts on tag
+        if: github.ref_type == 'tag'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-${{ github.ref }}
+          path: target\release
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"

--- a/src/pep.rs
+++ b/src/pep.rs
@@ -21,8 +21,6 @@ mod stringlist;
 pub use stringlist::{
     StringListItem,
     StringList,
-    StringListIterMut,
-    StringListIter,
 };
 
 // Transforms an error from some error type to the pep::Error.


### PR DESCRIPTION
This patch introduces a version upgrade of a vulnerable dependency, as well as fixes the CI/CD build for Windows and Ubuntu. Additionally, two unused imports are being removed.