### PR TITLE
CI/CD/Security/Minor change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: release
+
+on: push
+
+jobs:
+  ubuntu-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      CARGO_HOME: /home/runner/.cargo
+      PREFIX: /home/runner/install
+      LDFLAGS: -Wl,-rpath /home/runner/install/lib -L/home/runner/install/lib
+      CFLAGS: -I/home/runner/install/include
+      CXXFLAGS: -I/home/runner/install/include
+      RUSTFLAGS: -C link-arg=-L/home/runner/install/lib
+      GH_TOKEN: ${{ secrets.ALL_REPO_ACCESS_TOKEN }}
+    steps:
+      - name: Linux Cargo Cache
+        id: linux-cache-cargo
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cargo
+          key: linux-cache-cargo
+      - name: Get botan
+        run: |
+          mkdir -p /home/runner/install
+          cd /home/runner/install
+          gh release download lev -R plancksecurity/botan -p ubuntu-release.tar.bz2
+          tar xvfj ubuntu-release.tar.bz2
+          rm ubuntu-release.tar.bz2
+      - uses: actions/checkout@v4
+      - run: sudo apt install cargo
+      - run: make
+      - run: make install
+      - run: |
+          cd /home/runner/install
+          tar cvj . > ../ubuntu-release.tar.bz2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.head_ref || github.ref_name }}
+          files: /home/runner/ubuntu-release.tar.bz2
+          fail_on_unmatched_files: true
+
+  windows-release:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    env:
+      CARGO_HOME: "C:\\Users\\runneradmin\\.cargo"
+      GH_TOKEN: ${{ secrets.ALL_REPO_ACCESS_TOKEN }}
+      RUSTFLAGS: -luser32
+    steps:
+      - name: Get sources
+        uses: actions/checkout@v4
+      - name: Windows Cargo Cache
+        id: windows-cache-cargo
+        uses: actions/cache@v4
+        with:
+          path: "C:\\Users\\runneradmin\\.cargo"
+          key: windows-cache-cargo
+      - name: Get botan
+        run: |
+          mkdir C:\Users\runneradmin\install
+          cd C:\Users\runneradmin\install
+          gh release download lev -R plancksecurity/botan -p windows-release.zip
+          unzip windows-release.zip
+          rm windows-release.zip
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - name: Install
+        run: mv target\release\*pep_engine_sequoia_backend.* C:\Users\runneradmin\install\lib
+      - name: Compress
+        run: Compress-Archive -Path C:\Users\runneradmin\install\* -Destination windows-release.zip
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.head_ref || github.ref_name }}
+          files: windows-release.zip
+          fail_on_unmatched_files: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "memoffset",
  "rusqlite",
  "sequoia-openpgp",
+ "shlex",
  "thiserror",
 ]
 
@@ -1345,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,11 @@ rust-version = "1.63"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[dev-dependencies]
+shlex = "1.3.0"
+
 [dependencies]
+shlex = "1.3.0"
 anyhow = "1"
 backtrace = "0.3.61"
 chrono = "0.4.23"

--- a/build.rs
+++ b/build.rs
@@ -68,6 +68,7 @@ fn main() -> Result<(), std::io::Error> {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=pep_engine_sequoia_backend.pc.in");
+	println!(r"cargo:rustc-link-search=C:\Users\runneradmin\install\lib");
 
     eprintln!("Generated {:?} with:\n{}\nEOF", pc, content);
 

--- a/src/pep.rs
+++ b/src/pep.rs
@@ -21,8 +21,6 @@ mod stringlist;
 pub use stringlist::{
     StringListItem,
     StringList,
-    StringListIterMut,
-    StringListIter,
 };
 
 // Transforms an error from some error type to the pep::Error.


### PR DESCRIPTION
This patch introduces a version upgrade of a vulnerable dependency, as well as fixes the CI/CD build for Windows and Ubuntu. Additionally, two unused imports are being removed.